### PR TITLE
Dev 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 - [x] Slash command for statistic when using database
 - [x] Auto rebind on existing thread wehn staty restart
-- [ ] Slash command for enforce ping on an specific API
-- [ ] Rework of all logs
+- [ ] Button enforce ping on an specific API when is down
+- [x] Rework of all logs
 
 ## Changelog
+
+### `2.0.1`
+
+- Add new route `/ping/extern/stats` returning directly up and down time percentage
+- Fixing crash on getting a route without `Authorization` header
+- Staty send a message in configured channel with ping role associated on api to notify when api is down or reup
+- Reduce waiting time between two ping to 1 minute
+- Set default external port binding to `3007`
+- Docker image is now staged when is builded
 
 ### `2.0.0`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm i
 COPY . .
 RUN npm run build
 
-FROM node:20-slim
+FROM node:20-slim as runner
 
 WORKDIR /app
 COPY --from=builder /app/dist /app

--- a/README.md
+++ b/README.md
@@ -16,12 +16,8 @@ docker composer up -d --build
 
 ## Configuration files
 
-For configuration of Staty you must have these files : [data/secret.json](https://github.com/DigitalTeaCompany/staty/blob/main/config/secret.sample.json),
-[data/config.json](https://github.com/DigitalTeaCompany/staty/blob/main/config/global.sample.json).
+For configuration of Staty you must have this file : [.env.example](https://github.com/DigitalTeaCompany/staty/blob/main/.env.example).
 
 ### Configuration
 
 To create your discord app : [Discord Developers](https://discord.com/developers/applications)
-
-> [!WARNING]
-> Discord have rate limit of two actions in 10 minutes for bots on update name or description on channel and threads. Your wait time must be `>= 300000` ms ! Now Staty check this value since his version `0.1.5`.

--- a/app/functions/tester.ts
+++ b/app/functions/tester.ts
@@ -57,12 +57,7 @@ export const testing = async (
 
       try {
         // check if this api has removed from watching
-        const apiCheck = await StatyAxios.get(`/api/${api._id}`, {
-          headers: {
-            Authorization: `Bearer ${BOT_ID}`,
-          },
-        });
-
+        const apiCheck = await StatyAxios.get(`/api/${api._id}`);
         apiFetchedData = apiCheck.data.data;
 
         try {

--- a/app/functions/tester.ts
+++ b/app/functions/tester.ts
@@ -44,7 +44,7 @@ export const testing = async (
 ) => {
   const { BOT_ID } = process.env;
   const { wait } = params;
-  const waitingTime = wait >= 300000 ? wait : 300000;
+  const waitingTime = wait >= 60000 ? wait : 60000;
 
   try {
     // on error create a thread to details error and ping user

--- a/app/functions/tester.ts
+++ b/app/functions/tester.ts
@@ -49,9 +49,7 @@ export const testing = async (
   try {
     // on error create a thread to details error and ping user
     // on start and success nothings
-
     let lastApiState: number = 0;
-    let threadPing: ThreadChannelResolvable;
     let apiFetchedData: any;
 
     const pingInterval = setInterval(async () => {
@@ -130,7 +128,14 @@ export const testing = async (
               try {
                 const embed = new EmbedBuilder()
                   .setColor(parseInt("FFEC51", 16))
+                  .setTitle(apiFetchedData.api_name)
                   .setDescription(apiFetchedData.api_adress);
+                logs(
+                  null,
+                  "api:ping:down_api",
+                  `Api is down (${apiFetchedData.api_name}) [statyscore:${lastApiState}]`,
+                  params.guild.id
+                );
 
                 await params.state.send({
                   content: `<@&${params.role}> your api is down !`,
@@ -146,7 +151,12 @@ export const testing = async (
         }
       } catch (error: any) {
         // this api has removed from watching
-        logs("error", "ping:inactive:ping", error);
+        logs("error", "ping:inactive:ping", error.message);
+        logs(
+          "error",
+          "ping:inactive:ping",
+          `Cleaning interval (${pingInterval})`
+        );
         clearInterval(pingInterval);
       }
     }, waitingTime);


### PR DESCRIPTION
# `2.0.1`

- Add new route `/ping/extern/stats` returning directly up and down time percentage
- Fixing crash on getting a route without `Authorization` header
- Staty send a message in configured channel with ping role associated on api to notify when api is down or reup
- Reduce waiting time between two ping to 1 minute
- Set default external port binding to `3007`
- Docker image is now staged when is builded